### PR TITLE
Set the openjdk version to 7 for travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-  - openjdk6
+  - openjdk7


### PR DESCRIPTION
Hi!

The maven source code level is at Java 1.7. Since travis is set to openjdk6, every build will fail.

I hope this fixes this.

Cheers
ruwen