### PR TITLE
Add serialization support (while still keeping backwards compatibility)

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/pdu/AlertNotification.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/AlertNotification.java
@@ -32,6 +32,8 @@ import com.cloudhopper.smpp.util.PduUtil;
 
 public class AlertNotification extends Pdu {
 
+    private static final long serialVersionUID = 1L;
+
     protected Address sourceAddress;
     protected Address esmeAddress;
 

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseBind.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseBind.java
@@ -37,6 +37,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public abstract class BaseBind<R extends PduResponse> extends PduRequest<R> {
 
+    private static final long serialVersionUID = 1L;
+
     private String systemId;
     private String password;
     private String systemType;

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseBindResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseBindResp.java
@@ -33,6 +33,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public abstract class BaseBindResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     private String systemId;
 
     public BaseBindResp(int commandId, String name) {

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseSm.java
@@ -40,6 +40,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public abstract class BaseSm<R extends PduResponse> extends PduRequest<R> {
 
+    private static final long serialVersionUID = 1L;
+
     protected String serviceType;
     protected Address sourceAddress;
     protected Address destAddress;

--- a/src/main/java/com/cloudhopper/smpp/pdu/BaseSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BaseSmResp.java
@@ -33,6 +33,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public abstract class BaseSmResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     private String messageId;
 
     public BaseSmResp(int commandId, String name) {

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindReceiver.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindReceiver.java
@@ -28,6 +28,8 @@ import com.cloudhopper.smpp.SmppConstants;
  */
 public class BindReceiver extends BaseBind<BindReceiverResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public BindReceiver() {
         super(SmppConstants.CMD_ID_BIND_RECEIVER, "bind_receiver");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindReceiverResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindReceiverResp.java
@@ -28,6 +28,8 @@ import com.cloudhopper.smpp.SmppConstants;
  */
 public class BindReceiverResp extends BaseBindResp {
 
+    private static final long serialVersionUID = 1L;
+
     public BindReceiverResp() {
         super(SmppConstants.CMD_ID_BIND_RECEIVER_RESP, "bind_receiver_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindTransceiver.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindTransceiver.java
@@ -28,6 +28,8 @@ import com.cloudhopper.smpp.SmppConstants;
  */
 public class BindTransceiver extends BaseBind<BindTransceiverResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public BindTransceiver() {
         super(SmppConstants.CMD_ID_BIND_TRANSCEIVER, "bind_transceiver");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindTransceiverResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindTransceiverResp.java
@@ -28,6 +28,8 @@ import com.cloudhopper.smpp.SmppConstants;
  */
 public class BindTransceiverResp extends BaseBindResp {
 
+    private static final long serialVersionUID = 1L;
+
     public BindTransceiverResp() {
         super(SmppConstants.CMD_ID_BIND_TRANSCEIVER_RESP, "bind_transceiver_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindTransmitter.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindTransmitter.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class BindTransmitter extends BaseBind<BindTransmitterResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public BindTransmitter() {
         super(SmppConstants.CMD_ID_BIND_TRANSMITTER, "bind_transmitter");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/BindTransmitterResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/BindTransmitterResp.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class BindTransmitterResp extends BaseBindResp {
 
+    private static final long serialVersionUID = 1L;
+
     public BindTransmitterResp() {
         super(SmppConstants.CMD_ID_BIND_TRANSMITTER_RESP, "bind_transmitter_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/CancelSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/CancelSm.java
@@ -36,6 +36,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public class CancelSm extends PduRequest<CancelSmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     protected String serviceType;
     protected String messageId;
     protected Address sourceAddress;

--- a/src/main/java/com/cloudhopper/smpp/pdu/CancelSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/CancelSmResp.java
@@ -32,6 +32,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public class CancelSmResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     public CancelSmResp() {
         super(SmppConstants.CMD_ID_CANCEL_SM_RESP, "cancel_sm_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/DataSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/DataSm.java
@@ -29,6 +29,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public class DataSm extends BaseSm<DataSmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public DataSm() {
         super(SmppConstants.CMD_ID_DATA_SM, "data_sm");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/DataSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/DataSmResp.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class DataSmResp extends BaseSmResp {
 
+    private static final long serialVersionUID = 1L;
+
     public DataSmResp() {
         super(SmppConstants.CMD_ID_DATA_SM_RESP, "data_sm_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/DeliverSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/DeliverSm.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class DeliverSm extends BaseSm<DeliverSmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public DeliverSm() {
         super(SmppConstants.CMD_ID_DELIVER_SM, "deliver_sm");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/DeliverSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/DeliverSmResp.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class DeliverSmResp extends BaseSmResp {
 
+    private static final long serialVersionUID = 1L;
+
     public DeliverSmResp() {
         super(SmppConstants.CMD_ID_DELIVER_SM_RESP, "deliver_sm_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/EmptyBody.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/EmptyBody.java
@@ -26,6 +26,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public abstract class EmptyBody<R extends PduResponse> extends PduRequest<R> {
     
+    private static final long serialVersionUID = 1L;
+
     public EmptyBody(int commandId, String name) {
         super(commandId, name);
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/EmptyBodyResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/EmptyBodyResp.java
@@ -26,6 +26,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public abstract class EmptyBodyResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     public EmptyBodyResp(int commandId, String name) {
         super(commandId, name);
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/EnquireLink.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/EnquireLink.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class EnquireLink extends EmptyBody<EnquireLinkResp> {
     
+    private static final long serialVersionUID = 1L;
+
     public EnquireLink() {
         super(SmppConstants.CMD_ID_ENQUIRE_LINK, "enquire_link");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/EnquireLinkResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/EnquireLinkResp.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class EnquireLinkResp extends EmptyBodyResp {
 
+    private static final long serialVersionUID = 1L;
+
     public EnquireLinkResp() {
         super(SmppConstants.CMD_ID_ENQUIRE_LINK_RESP, "enquire_link_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/GenericNack.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/GenericNack.java
@@ -27,6 +27,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public class GenericNack extends PduResponse {
     
+    private static final long serialVersionUID = 1L;
+
     public GenericNack() {
         super(SmppConstants.CMD_ID_GENERIC_NACK, "generic_nack");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/PartialPdu.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/PartialPdu.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.pdu;
 
 public class PartialPdu extends EmptyBody<GenericNack> {
     
+    private static final long serialVersionUID = 1L;
+
     public PartialPdu(int commandId) {
         super(commandId, "partial_pdu");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/PartialPduResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/PartialPduResp.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.pdu;
 
 public class PartialPduResp extends EmptyBodyResp {
     
+    private static final long serialVersionUID = 1L;
+
     public PartialPduResp(int commandId) {
         super(commandId, "partial_pdu_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/Pdu.java
@@ -27,10 +27,14 @@ import com.cloudhopper.smpp.SmppConstants;
 import com.cloudhopper.smpp.tlv.Tlv;
 import com.cloudhopper.smpp.transcoder.PduTranscoderContext;
 import com.cloudhopper.smpp.util.ChannelBufferUtil;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import org.jboss.netty.buffer.ChannelBuffer;
 
-public abstract class Pdu {
+public abstract class Pdu implements Serializable {
+
+    private static final long serialVersionUID = 1L;
     
     private final String name;
     private final boolean isRequest;
@@ -52,6 +56,7 @@ public abstract class Pdu {
         this.referenceObject = null;
     }
 
+    // value has to implement Serializable if serialization is used
     public void setReferenceObject(Object value) {
         this.referenceObject = value;
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/PduRequest.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/PduRequest.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.pdu;
 
 public abstract class PduRequest<R extends PduResponse> extends Pdu {
 
+    private static final long serialVersionUID = 1L;
+
     public PduRequest(int commandId, String name) {
         super(commandId, name, true);
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/PduResponse.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/PduResponse.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.pdu;
 
 public abstract class PduResponse extends Pdu {
 
+    private static final long serialVersionUID = 1L;
+
     private String resultMessage;
     
     public PduResponse(int commandId, String name) {

--- a/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/QuerySm.java
@@ -36,6 +36,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public class QuerySm extends PduRequest<QuerySmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     private String messageId;
     private Address sourceAddress;
 

--- a/src/main/java/com/cloudhopper/smpp/pdu/QuerySmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/QuerySmResp.java
@@ -36,6 +36,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
  */
 public class QuerySmResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     private String messageId;
     private String finalDate;
     private byte messageState;

--- a/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSm.java
@@ -34,6 +34,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public class ReplaceSm extends PduRequest<ReplaceSmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     private String messageId;
     private Address sourceAddress;
     private String scheduleDeliveryTime;

--- a/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/ReplaceSmResp.java
@@ -28,6 +28,8 @@ import com.cloudhopper.smpp.type.UnrecoverablePduException;
 
 public class ReplaceSmResp extends PduResponse {
 
+    private static final long serialVersionUID = 1L;
+
     public ReplaceSmResp() {
         super(SmppConstants.CMD_ID_REPLACE_SM_RESP, "replace_sm_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/SubmitSm.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/SubmitSm.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class SubmitSm extends BaseSm<SubmitSmResp> {
 
+    private static final long serialVersionUID = 1L;
+
     public SubmitSm() {
         super(SmppConstants.CMD_ID_SUBMIT_SM, "submit_sm");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/SubmitSmResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/SubmitSmResp.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class SubmitSmResp extends BaseSmResp {
 
+    private static final long serialVersionUID = 1L;
+
     public SubmitSmResp() {
         super(SmppConstants.CMD_ID_SUBMIT_SM_RESP, "submit_sm_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/Unbind.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/Unbind.java
@@ -24,6 +24,8 @@ import com.cloudhopper.smpp.SmppConstants;
 
 public class Unbind extends EmptyBody<UnbindResp> {
     
+    private static final long serialVersionUID = 1L;
+
     public Unbind() {
         super(SmppConstants.CMD_ID_UNBIND, "unbind");
     }

--- a/src/main/java/com/cloudhopper/smpp/pdu/UnbindResp.java
+++ b/src/main/java/com/cloudhopper/smpp/pdu/UnbindResp.java
@@ -27,6 +27,8 @@ import org.jboss.netty.buffer.ChannelBuffer;
 
 public class UnbindResp extends EmptyBodyResp {
 
+    private static final long serialVersionUID = 1L;
+
     public UnbindResp() {
         super(SmppConstants.CMD_ID_UNBIND_RESP, "unbind_resp");
     }

--- a/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
+++ b/src/main/java/com/cloudhopper/smpp/tlv/Tlv.java
@@ -22,6 +22,8 @@ package com.cloudhopper.smpp.tlv;
 
 import com.cloudhopper.commons.util.ByteArrayUtil;
 import com.cloudhopper.commons.util.HexUtil;
+
+import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
@@ -30,7 +32,9 @@ import java.util.Arrays;
  * 
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
-public class Tlv {
+public class Tlv implements Serializable {
+
+    private static final long serialVersionUID = 1L;
     
     private final short tag;
     private final byte[] value;     // length is stored in array

--- a/src/main/java/com/cloudhopper/smpp/type/Address.java
+++ b/src/main/java/com/cloudhopper/smpp/type/Address.java
@@ -26,12 +26,16 @@ import com.cloudhopper.smpp.util.ChannelBufferUtil;
 import com.cloudhopper.smpp.util.PduUtil;
 import org.jboss.netty.buffer.ChannelBuffer;
 
+import java.io.Serializable;
+
 /**
  * Simple representation of an Address in SMPP.
  * 
  * @author joelauer (twitter: @jjlauer or <a href="http://twitter.com/jjlauer" target=window>http://twitter.com/jjlauer</a>)
  */
-public class Address {
+public class Address implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     private byte ton;
     private byte npi;


### PR DESCRIPTION
I propose adding serialization support to PDU-s. I have tested it and it worked fine.

User can still break serialization by adding non-serializable object to a PDU using setReferenceObject(). It would be possible to change the method signature for this method so it would take only a serializable parameter but this would break backwards compatibility so I just added a comment.

The other way would be to deprecate current method and add new method, something like this:
    /**
     * @deprecated  Replaced by {@link #setReference(Object)}
     */
    @Deprecated
    public void setReferenceObject(Object value) {
        this.referenceObject = value;
    }

    public <T extends Serializable> void setReference(T value) {
        this.referenceObject = value;
    }






