### PR TITLE
Open connection with specified local address.

### DIFF
--- a/src/main/java/com/cloudhopper/smpp/type/SmppConnectionConfiguration.java
+++ b/src/main/java/com/cloudhopper/smpp/type/SmppConnectionConfiguration.java
@@ -32,7 +32,8 @@ public class SmppConnectionConfiguration {
     private String host;
     private int port;
     private long connectTimeout;
-
+    private String localAddress;
+    private int localPort;
     public SmppConnectionConfiguration() {
         this(null, 0, SmppConstants.DEFAULT_CONNECT_TIMEOUT);
     }
@@ -66,5 +67,21 @@ public class SmppConnectionConfiguration {
     public long getConnectTimeout() {
         return this.connectTimeout;
     }
+
+	public String getLocalAddress() {
+		return localAddress;
+	}
+
+	public void setLocalAddress(String localAddress) {
+		this.localAddress = localAddress;
+	}
+
+	public int getLocalPort() {
+		return localPort;
+	}
+
+	public void setLocalPort(int localPort) {
+		this.localPort = localPort;
+	}
 
 }


### PR DESCRIPTION
I'm facing a sitution in which our server has two ip addresses(one of them is virtual) and only the virtual ip is authorized by the SMSC of our partner.So I need to open connection with the virtual ip to be able to communicate with the SMSC while cloudhopper don't allow me to specify the ip address I want to use to open connection when establishing bind with SMSC. 
The only solution I've found is to replace the interface connect(SocketAddress remoteAddress) by connect(SocketAddress remoteAddress, SocketAddress localAddress) of org.jboss.netty.bootstrap.ClientBootstrap  in order to be able to specify the ip address I want to use to open connection.